### PR TITLE
PSG support

### DIFF
--- a/lsst_cometary_colors/psg_routines.py
+++ b/lsst_cometary_colors/psg_routines.py
@@ -3,6 +3,7 @@ import requests
 from urllib.parse import quote
 
 import astropy.units as u
+from synphot import SourceSpectrum
 
 @u.quantity_input(fwhm=u.arcsec, resolution=u.nm)
 def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec, resolution=1*u.nm):
@@ -130,3 +131,16 @@ def generate_psg_spectrum(config_file):
         filename = None
 
     return filename
+
+def read_psg_spectrum(spectrum):
+    """Reads a spectrum file produced by PSG from <spectrum> and returns a
+    `synphot.SourceSpectrum`
+    """
+
+    # Units for PSG config files from generate_psg_config_file()
+    # (Could read the units in the PSG header if we wanted to)
+    psg_units = u.W/u.m**2/u.um
+
+    sourcespec = SourceSpectrum.from_file(spectrum, wave_unit=u.nm, flux_unit=psg_units)
+
+    return sourcespec

--- a/lsst_cometary_colors/psg_routines.py
+++ b/lsst_cometary_colors/psg_routines.py
@@ -1,0 +1,82 @@
+import os
+
+import astropy.units as u
+
+@u.quantity_input(fwhm=u.arcsec)
+def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec):
+
+    config_lines = ['<OBJECT>Comet',
+                    '<OBJECT-DIAMETER>7.00',
+                    '<OBJECT-GRAVITY>0.600',
+                    '<OBJECT-GRAVITY-UNIT>rho',
+                   f'<OBJECT-STAR-DISTANCE>{helio_dist:}',
+                    '<OBJECT-STAR-TYPE>G',
+                    '<OBJECT-STAR-TEMPERATURE>5777',
+                    '<OBJECT-STAR-RADIUS>1.0',
+                    '<GEOMETRY>Observatory',
+                    '<GEOMETRY-OFFSET-NS>0.0',
+                    '<GEOMETRY-OFFSET-EW>0.0',
+                    '<GEOMETRY-OFFSET-UNIT>arcsec',
+                   f'<GEOMETRY-OBS-ALTITUDE>{geo_dist:}',
+                    '<GEOMETRY-ALTITUDE-UNIT>AU',
+                    '<ATMOSPHERE-STRUCTURE>Coma',
+                    '<ATMOSPHERE-PRESSURE>7.5e+27',
+                    '<ATMOSPHERE-PUNIT>gas',
+                    '<ATMOSPHERE-TEMPERATURE>38.1',
+                    '<ATMOSPHERE-WEIGHT>471.57',
+                    '<ATMOSPHERE-NGAS>4',
+                    '<ATMOSPHERE-GAS>OH,CN,C2,NH',
+                    '<ATMOSPHERE-TYPE>GSFC[OH],GSFC[CN],GSFC[C2],GSFC[NH]',
+                    '<ATMOSPHERE-ABUN>100,0.35,0.2,0.3',
+                    '<ATMOSPHERE-UNIT>pct,pct,pct,pct',
+                    '<ATMOSPHERE-TAU>2.4e4 1.6e5,1.3e4 2.1e5,2.2e4 6.6e4,5.0e4 1.5e5',
+                    '<SURFACE-TEMPERATURE>162.3',
+                    '<SURFACE-ALBEDO>0.04',
+                    '<SURFACE-EMISSIVITY>0.2',
+                    '<SURFACE-NSURF>0',
+                    '<SURFACE-SURF>',
+                    '<SURFACE-TYPE>',
+                    '<SURFACE-ABUN>',
+                    '<SURFACE-UNIT>',
+                    '<SURFACE-THICK>',
+                    '<SURFACE-GAS-RATIO>100',
+                    '<SURFACE-GAS-UNIT>afrho',
+                    '<SURFACE-MODEL>Lommel-Seeliger,HG1,0.000',
+                    '<GENERATOR-RESOLUTIONKERNEL>N',
+                    '<ATMOSPHERE-NMAX>0',
+                    '<ATMOSPHERE-LMAX>0',
+                    '<ATMOSPHERE-NAERO>0',
+                    '<ATMOSPHERE-AEROS>',
+                    '<ATMOSPHERE-ATYPE>',
+                    '<ATMOSPHERE-AABUN>',
+                    '<ATMOSPHERE-AUNIT>',
+                    '<ATMOSPHERE-ASIZE>',
+                    '<ATMOSPHERE-ASUNI>',
+                    '<ATMOSPHERE-CONTINUUM>Rayleigh,Refraction,CIA_all,UV_all',
+                    '<SURFACE-PHASEG>',
+                    '<GENERATOR-INSTRUMENT>user',
+                    '<GENERATOR-RANGE1>300',
+                    '<GENERATOR-RANGE2>1200',
+                    '<GENERATOR-RANGEUNIT>nm',
+                    '<GENERATOR-RESOLUTION>1',
+                    '<GENERATOR-RESOLUTIONUNIT>nm',
+                    '<GENERATOR-RADUNITS>Wm2um',
+                   f'<GENERATOR-BEAM>{fwhm.to(u.arcsec).value:}',
+                   f'<GENERATOR-BEAM-UNIT>{fwhm.to(u.arcsec).unit:}',
+                    '<GENERATOR-TELESCOPE>SINGLE',
+                    '<GENERATOR-NOISE>NO',
+                    '<GENERATOR-TRANS-APPLY>N',
+                    '<GENERATOR-TRANS-SHOW>N',
+                    '<GENERATOR-TRANS>02-01',
+                    '<GENERATOR-LOGRAD>N',
+                    '<GENERATOR-GAS-MODEL>Y',
+                    '<GENERATOR-CONT-MODEL>Y',
+                    '<GENERATOR-CONT-STELLAR>Y',
+                   ]
+
+    filename= os.path.join(output_location, f"psg_config.txt")
+
+    with open(filename, 'w') as fh:
+        fh.writelines([line + '\n' for line in config_lines])
+
+    return filename

--- a/lsst_cometary_colors/psg_routines.py
+++ b/lsst_cometary_colors/psg_routines.py
@@ -2,8 +2,8 @@ import os
 
 import astropy.units as u
 
-@u.quantity_input(fwhm=u.arcsec)
-def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec):
+@u.quantity_input(fwhm=u.arcsec, resolution=u.nm)
+def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec, resolution=1*u.nm):
 
     config_lines = ['<OBJECT>Comet',
                     '<OBJECT-DIAMETER>7.00',
@@ -42,7 +42,6 @@ def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.973
                     '<SURFACE-GAS-RATIO>100',
                     '<SURFACE-GAS-UNIT>afrho',
                     '<SURFACE-MODEL>Lommel-Seeliger,HG1,0.000',
-                    '<GENERATOR-RESOLUTIONKERNEL>N',
                     '<ATMOSPHERE-NMAX>0',
                     '<ATMOSPHERE-LMAX>0',
                     '<ATMOSPHERE-NAERO>0',
@@ -58,11 +57,12 @@ def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.973
                     '<GENERATOR-RANGE1>300',
                     '<GENERATOR-RANGE2>1200',
                     '<GENERATOR-RANGEUNIT>nm',
-                    '<GENERATOR-RESOLUTION>1',
-                    '<GENERATOR-RESOLUTIONUNIT>nm',
+                   f'<GENERATOR-RESOLUTION>{resolution.to(u.nm).value:}',
+                   f'<GENERATOR-RESOLUTIONUNIT>{resolution.to(u.nm).unit:}',
                     '<GENERATOR-RADUNITS>Wm2um',
                    f'<GENERATOR-BEAM>{fwhm.to(u.arcsec).value:}',
                    f'<GENERATOR-BEAM-UNIT>{fwhm.to(u.arcsec).unit:}',
+                    '<GENERATOR-RESOLUTIONKERNEL>N',
                     '<GENERATOR-TELESCOPE>SINGLE',
                     '<GENERATOR-NOISE>NO',
                     '<GENERATOR-TRANS-APPLY>N',

--- a/lsst_cometary_colors/psg_routines.py
+++ b/lsst_cometary_colors/psg_routines.py
@@ -6,7 +6,20 @@ import astropy.units as u
 from synphot import SourceSpectrum
 
 @u.quantity_input(fwhm=u.arcsec, resolution=u.nm)
-def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec, resolution=1*u.nm):
+def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.9737, fwhm=4*u.arcsec, resolution=1*u.nm, afrho=100, activity=7.5e27):
+    """Generates a comet configuration file in <output_location> for the
+    NASA Planetary Spectrum Generator (PSG) which can be uploaded or submitted
+    via the API (see `generate_psg_spectrum()`).
+    The optional configurable parameters are:
+    * helio_dist: heliocentric distance of comet from the Sun (au),
+    * geo_dist: geocentric distance of comet from the Earth (au),
+    * fwhm: the FWHM of the instrument FOV (Astropy Quantity, transformable to arcsec),
+    * resolution: the resolution of the generated spectrum (covers 300-1200nm; Astropy Quantity, transformable to nm),
+    * afrho: Afrho (cm; used as unit of dust abundance for PSG),
+    * activity: Atmospheric activity (molecules/sec)
+
+    The pathname of the config file is returned.
+    """
 
     config_lines = ['<OBJECT>Comet',
                     '<OBJECT-DIAMETER>7.00',
@@ -39,7 +52,7 @@ def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.973
                     '<GEOMETRY-STAR-FRACTION>0.000000e+00',
                     '<GEOMETRY-ROTATION>0.00,0.00',
                     '<ATMOSPHERE-STRUCTURE>Coma',
-                    '<ATMOSPHERE-PRESSURE>7.5e+27',
+                   f'<ATMOSPHERE-PRESSURE>{activity:}',
                     '<ATMOSPHERE-PUNIT>gas',
                     '<ATMOSPHERE-TEMPERATURE>38.1',
                     '<ATMOSPHERE-WEIGHT>471.57',
@@ -58,7 +71,7 @@ def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.973
                     '<SURFACE-ABUN>',
                     '<SURFACE-UNIT>',
                     '<SURFACE-THICK>',
-                    '<SURFACE-GAS-RATIO>100',
+                   f'<SURFACE-GAS-RATIO>{afrho:}',
                     '<SURFACE-GAS-UNIT>afrho',
                     '<SURFACE-MODEL>Lommel-Seeliger,HG1,0.000',
                     '<ATMOSPHERE-NMAX>0',
@@ -103,7 +116,7 @@ def generate_psg_config_file(output_location, helio_dist=2.87796, geo_dist=2.973
 def generate_psg_spectrum(config_file):
     """Calls the Planetary Spectrum Generator via the API service to compute
     a radiance spectrum with the configuration from <config_file> and saves it to disk
-    as 'psg_spectrum.txt> in the same directory as the config_file (overwrites any
+    as 'psg_spectrum.txt' in the same directory as the config_file (overwrites any
     existing version).
     The path to the spectrum is returned"""
 

--- a/lsst_cometary_colors/tests/test_psg_routines.py
+++ b/lsst_cometary_colors/tests/test_psg_routines.py
@@ -1,8 +1,12 @@
 import os
 import tempfile, shutil
 import pytest
+import warnings
 
 import astropy.units as u
+warnings.simplefilter("ignore", pytest.PytestUnknownMarkWarning)
+from astropy.tests.helper import assert_quantity_allclose
+from synphot.spectrum import SourceSpectrum
 
 from lsst_cometary_colors.psg_routines import *
 
@@ -146,3 +150,21 @@ class TestGeneratePSGSpectrum:
         assert os.path.exists(spectrum_file) is True
         assert os.path.getsize(spectrum_file) == 2339
 
+class TestReadPSGSpectrum:
+
+    funit = u.W/u.m**2/u.micron
+
+    test_spectrum_fp = os.path.abspath(os.path.join(__package__, 'lsst_cometary_colors', "tests", "data", "psg_spectrum.txt"))
+
+    def test_spectrum_exists(self):
+        assert os.path.exists(self.test_spectrum_fp) is True
+
+    def test_spectrum(self):
+
+        source_spec = read_psg_spectrum(self.test_spectrum_fp)
+
+        assert type(source_spec) == SourceSpectrum
+        assert_quantity_allclose(source_spec.waveset[0], 300 * u.nm)
+        assert_quantity_allclose(source_spec(source_spec.waveset[0], flux_unit='FLAM'), 4.4279706e-16*self.funit)
+        assert_quantity_allclose(source_spec.waveset[-1], 1200 * u.nm)
+        assert_quantity_allclose(source_spec(source_spec.waveset[-1], flux_unit='FLAM'), 4.7801348e-16*self.funit)

--- a/lsst_cometary_colors/tests/test_psg_routines.py
+++ b/lsst_cometary_colors/tests/test_psg_routines.py
@@ -1,0 +1,110 @@
+import os
+import tempfile, shutil
+import pytest
+
+import astropy.units as u
+
+from lsst_cometary_colors.psg_routines import *
+
+
+class TestGenerateConfig(object):
+
+    @pytest.fixture
+    def test_dir(self, tmp_path_factory):
+        return tmp_path_factory.mktemp('tmp_lsst_', numbered=True)
+
+    def test_exists(self, test_dir):
+
+        config_file = generate_psg_config_file(test_dir)
+
+        assert os.path.exists(config_file) is True
+
+    def test_change_rh(self, test_dir):
+
+        r_h = 2.1234
+
+        config_file = generate_psg_config_file(test_dir, helio_dist=r_h)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        line = [line.rstrip() for line in lines if 'OBJECT-STAR-DISTANCE' in line]
+        assert f'<OBJECT-STAR-DISTANCE>{r_h:}' == line[0]
+
+    def test_change_delta(self, test_dir):
+
+        delta = 1.001
+
+        config_file = generate_psg_config_file(test_dir, geo_dist=delta)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        line = [line.rstrip() for line in lines if 'GEOMETRY-OBS-ALTITUDE' in line]
+        assert f'<GEOMETRY-OBS-ALTITUDE>{delta:}' == line[0]
+
+    def test_change_both(self, test_dir):
+
+        r_h = 2.1234
+        delta = 1.001
+
+        config_file = generate_psg_config_file(test_dir, r_h, delta)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        line = [line.rstrip() for line in lines if 'GEOMETRY-OBS-ALTITUDE' in line]
+        assert f'<GEOMETRY-OBS-ALTITUDE>{delta:}' == line[0]
+        line = [line.rstrip() for line in lines if 'OBJECT-STAR-DISTANCE' in line]
+        assert f'<OBJECT-STAR-DISTANCE>{r_h:}' == line[0]
+
+    def test_fwhm_default(self, test_dir):
+
+        config_file = generate_psg_config_file(test_dir)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'GENERATOR-BEAM' : 4.0,
+                   'GENERATOR-BEAM-UNIT' : 'arcsec'
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
+    def test_fwhm_newval(self, test_dir):
+
+        fwhm = 5.0*u.arcsec
+        config_file = generate_psg_config_file(test_dir, fwhm=fwhm)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'GENERATOR-BEAM' : fwhm.value,
+                   'GENERATOR-BEAM-UNIT' : 'arcsec'
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
+    def test_fwhm_newunits(self, test_dir):
+
+        fwhm = 0.1*u.arcmin
+        config_file = generate_psg_config_file(test_dir, fwhm=fwhm)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'GENERATOR-BEAM' : fwhm.to(u.arcsec).value,
+                   'GENERATOR-BEAM-UNIT' : fwhm.to(u.arcsec).unit
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
+    def test_fwhm_badunits(self, test_dir):
+
+        fwhm = 5
+        with pytest.raises(TypeError) as execinfo:
+            config_file = generate_psg_config_file(test_dir, fwhm=fwhm)
+

--- a/lsst_cometary_colors/tests/test_psg_routines.py
+++ b/lsst_cometary_colors/tests/test_psg_routines.py
@@ -133,6 +133,35 @@ class TestGenerateConfig(object):
         with pytest.raises(TypeError) as execinfo:
             config_file = generate_psg_config_file(test_dir, resolution=resolution)
 
+    def test_afrho(self, test_dir):
+
+        afrho = 2700
+        config_file = generate_psg_config_file(test_dir, afrho=afrho)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'SURFACE-GAS-RATIO' : afrho,
+                   'SURFACE-GAS-UNIT' : 'afrho'
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
+    def test_activity(self, test_dir):
+
+        Q = 1e27
+        config_file = generate_psg_config_file(test_dir, activity=Q)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'ATMOSPHERE-PRESSURE' : Q,
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
 
 class TestGeneratePSGSpectrum:
 

--- a/lsst_cometary_colors/tests/test_psg_routines.py
+++ b/lsst_cometary_colors/tests/test_psg_routines.py
@@ -129,3 +129,20 @@ class TestGenerateConfig(object):
         with pytest.raises(TypeError) as execinfo:
             config_file = generate_psg_config_file(test_dir, resolution=resolution)
 
+
+class TestGeneratePSGSpectrum:
+
+    @pytest.fixture(scope='session')
+    def config_file(self, tmp_path_factory):
+        config_path = tmp_path_factory.mktemp('tmp_psg_')
+        config_file = generate_psg_config_file(config_path, resolution=100*u.nm)
+        return config_file
+
+    def test_exists(self, config_file):
+
+        spectrum_file = generate_psg_spectrum(config_file)
+
+        assert os.path.exists(config_file) is True
+        assert os.path.exists(spectrum_file) is True
+        assert os.path.getsize(spectrum_file) == 2339
+

--- a/lsst_cometary_colors/tests/test_psg_routines.py
+++ b/lsst_cometary_colors/tests/test_psg_routines.py
@@ -108,3 +108,24 @@ class TestGenerateConfig(object):
         with pytest.raises(TypeError) as execinfo:
             config_file = generate_psg_config_file(test_dir, fwhm=fwhm)
 
+    def test_resolution_newunits(self, test_dir):
+
+        resolution = 1000*u.AA
+        config_file = generate_psg_config_file(test_dir, resolution=resolution)
+
+        with open(config_file, 'r') as fh:
+            lines = fh.readlines()
+
+        checks = { 'GENERATOR-RESOLUTION' : resolution.to(u.nm).value,
+                   'GENERATOR-RESOLUTIONUNIT' : resolution.to(u.nm).unit
+                 }
+        for key, value in checks.items():
+            line = [line.rstrip() for line in lines if key in line]
+            assert f'<{key:}>{value:}' == line[0]
+
+    def test_resolution_badunits(self, test_dir):
+
+        resolution = 5
+        with pytest.raises(TypeError) as execinfo:
+            config_file = generate_psg_config_file(test_dir, resolution=resolution)
+

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore:The distutils:DeprecationWarning

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+pytest
+astropy
 -e git+https://git@github.com/NASA-Planetary-Science/sbpy.git#egg=sbpy


### PR DESCRIPTION
Add support for autogeneration of config files for NASA's Planetary Spectrum Generator (PSG), API query of PSG for retrieving a spectrum and support for turning the result into a `synphot.SourceSpectrum`. More can be done to produce non-overwriting config/spectrum files and physically plausible PSG config files but it's a good basis to build on.